### PR TITLE
Add OpenAI Whisper transcription script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,16 @@
-# VoiceRecorderTranscriber
+# Voice Recorder Transcriber
+
+This project provides a simple command-line tool to send an audio file to OpenAI's Whisper API and print the transcription.
+
+## Requirements
+- Python 3.8+
+- An OpenAI API key available in the environment variable `OPENAI_API_KEY`
+- The `openai` Python package (`pip install openai`)
+
+## Usage
+```
+python transcribe.py path/to/audio_file
+```
+
+The script uploads the specified audio file to OpenAI and outputs the transcribed text.
+

--- a/transcribe.py
+++ b/transcribe.py
@@ -1,0 +1,29 @@
+import argparse
+import openai
+import os
+
+
+def transcribe_file(path: str) -> str:
+    """Upload an audio file to OpenAI and return the transcription text."""
+    api_key = os.environ.get("OPENAI_API_KEY")
+    if not api_key:
+        raise EnvironmentError("OPENAI_API_KEY environment variable not set")
+    openai.api_key = api_key
+
+    with open(path, "rb") as audio_file:
+        transcript = openai.Audio.transcribe("whisper-1", audio_file)
+    return transcript["text"]
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Transcribe an audio file using OpenAI's Whisper API")
+    parser.add_argument("file", help="Path to the audio file")
+    args = parser.parse_args()
+
+    text = transcribe_file(args.file)
+    print(text)
+
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
## Summary
- implement simple `transcribe.py` to send audio files to OpenAI Whisper
- document usage in README

## Testing
- `python3 -m py_compile transcribe.py`

------
https://chatgpt.com/codex/tasks/task_e_6870eeaa659083218d5acd15f8d903fa